### PR TITLE
[TEMP] Disable auth backend for webdav clients

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ The integration requires an Identity Provider that supports OpenID Connect (e.g.
 More information on setup, configuration and migration can be found in the ownCloud Documentation.</description>
     <licence>GPLv2</licence>
     <author>Thomas Müller</author>
-    <version>2.0.2a1</version>
+    <version>2.0.2a2</version>
     <namespace>CesnetOpenIdConnect</namespace>
     <category>integration</category>
     <documentation>

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -71,8 +71,10 @@ class Application extends App {
 
 		// Add event listener
 		$dispatcher = $server->getEventDispatcher();
-		$eventHandler = new EventHandler($dispatcher, $request, $userSession, $session);
-		$eventHandler->registerEventHandler();
+
+//		TODO: Uncomment this to enable OpenIDConnect support for ownCloud clients
+//		$eventHandler = new EventHandler($dispatcher, $request, $userSession, $session);
+//		$eventHandler->registerEventHandler();
 
 		// verify the session
 		$sessionVerifier = new SessionVerifier($this->logger, $session, $userSession, $memCacheFactory, $dispatcher, $client);

--- a/lib/OpenIdConnectAuthModule.php
+++ b/lib/OpenIdConnectAuthModule.php
@@ -62,10 +62,10 @@ class OpenIdConnectAuthModule implements IAuthModule {
 	 * @param Client $client
 	 */
 	public function __construct(IUserManager $manager,
-								   ILogger $logger,
-								   ICacheFactory $cacheFactory,
-								   UserLookupService $lookupService,
-								   Client $client) {
+								ILogger $logger,
+								ICacheFactory $cacheFactory,
+								UserLookupService $lookupService,
+								Client $client) {
 		$this->manager = $manager;
 		$this->logger = new Logger($logger);
 		$this->cacheFactory = $cacheFactory;


### PR DESCRIPTION
Temporarily disable this auth method for desktop clients that are currently incompatible (due to current MitreID implementation of native apps loopback redirect URIs)